### PR TITLE
emit drain immediately, with safe state transition

### DIFF
--- a/index.js
+++ b/index.js
@@ -63,10 +63,8 @@ function duplex (reader, read) {
         cbs.push(cb)
 
       if (needDrain) {
-        next(function () {
-          s.emit('drain')
-        })
         needDrain = false
+        s.emit('drain')
       }
     }
   }
@@ -136,3 +134,4 @@ function duplex (reader, read) {
 
   return s
 }
+


### PR DESCRIPTION
I suggest making this change, unless you have a reason to emit the drain after `nextTick`?

if you move `needDrain=false` before `emit('drain')` but inside `next()` then it also works.
however, if you have it outside the next, it would be possible to switch in and out of the `needDrain` state without emitting drain (at least as far as those couple of lines of code are concerned) queuing up actually multiple `emit('drain')` calls.
